### PR TITLE
Changes for Ops

### DIFF
--- a/cluster-login.sh
+++ b/cluster-login.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-output=$(./kubectl-login $1 | tee /dev/stderr)
+output=$(kubectl-login $1 | tee /dev/stderr)
 
 kubectlLoginOutput=($output)
 
+# Output returns the redirect url (for Ops) and the kubeconfig
+# Get the kubeconfig path and set the KUBECONFIG environment varible
 if [ ${#kubectlLoginOutput[@]} -eq 2  ]
 then
     export KUBECONFIG=${output} | awk '{print $2; }'
     echo "Logged in to $1. Using KUBECONFIG=$KUBECONFIG"
+# Output returns the kubeconfig path which is set an the KUBECONFIG environment varible
 elif [ ${#kubectlLoginOutput[@]} -eq 1 ]
 then
     export KUBECONFIG=${output}

--- a/cluster-login.sh
+++ b/cluster-login.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
-output=$(kubectl-login $1)
-if [ $? -eq 0  ]
+output=$(./kubectl-login $1 | tee /dev/stderr)
+
+kubectlLoginOutput=($output)
+
+if [ ${#kubectlLoginOutput[@]} -eq 2  ]
+then
+    export KUBECONFIG=${output} | awk '{print $2; }'
+    echo "Logged in to $1. Using KUBECONFIG=$KUBECONFIG"
+elif [ ${#kubectlLoginOutput[@]} -eq 1 ]
 then
     export KUBECONFIG=${output}
     echo "Logged in to $1. Using KUBECONFIG=$KUBECONFIG"

--- a/main.go
+++ b/main.go
@@ -75,12 +75,13 @@ func main() {
 
 	redirectUrl := oauth2Config.AuthCodeURL(state)
 	logger.Println(redirectUrl)
-	err = openBrowser(redirectUrl)
- 	if err != nil {
-		if err != exec.ErrNotFound {
-			logger.Fatalf("error: cannot open browser: %v", err)
-		}
-	}
+	browserErr := openBrowser(redirectUrl)
+
+    if browserErr != nil {
+            if !strings.Contains(browserErr.Error(), "executable file not found in $PATH") {
+                    logger.Fatalf("error: cannot open browser: %v", browserErr)
+            }
+    }
 
 	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})
 	tokensInput := readTokens()

--- a/main.go
+++ b/main.go
@@ -76,12 +76,12 @@ func main() {
 	redirectUrl := oauth2Config.AuthCodeURL(state)
 	logger.Println(redirectUrl)
 	browserErr := openBrowser(redirectUrl)
-
-    if browserErr != nil {
-            if !strings.Contains(browserErr.Error(), "executable file not found in $PATH") {
-                    logger.Fatalf("error: cannot open browser: %v", browserErr)
-            }
-    }
+	
+	if browserErr != nil {
+    	if !strings.Contains(browserErr.Error(), "executable file not found in $PATH") {
+        	logger.Fatalf("error: cannot open browser: %v", browserErr)
+        }
+	}
 
 	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})
 	tokensInput := readTokens()

--- a/main.go
+++ b/main.go
@@ -73,8 +73,13 @@ func main() {
 		Scopes:       []string{oidc.ScopeOpenID, "profile", "email", "groups", "offline_access"}, // "openid" is a required scope for OpenID Connect flows.
 	}
 
-	if err = openBrowser(oauth2Config.AuthCodeURL(state)); err != nil {
-		logger.Fatalf("error: cannot open browser: %v", err)
+	redirectUrl := oauth2Config.AuthCodeURL(state)
+	logger.Println(redirectUrl)
+	err = openBrowser(redirectUrl)
+ 	if err != nil {
+		if err != exec.ErrNotFound {
+			logger.Fatalf("error: cannot open browser: %v", err)
+		}
 	}
 
 	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})


### PR DESCRIPTION
Ops use a linux server to access our clusters which doesn't have browser support. 
So display the url on the cli so that they can open the link manually and get the auth code.

This was tested on Mac, Linux and Windows