### PR TITLE
Set context name to be same as cluster

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,76 +3,105 @@
 
 [[projects]]
   branch = "v2"
+  digest = "1:c49642f3dd1cc284ed2494123c62a938471728a137895229335b0d2af955d507"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
+  pruneopts = "UT"
   revision = "065b426bd41667456c1a924468f507673629c46b"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:ffc060c551980d37ee9e428ef528ee2813137249ccebb0bfc412ef83071cac91"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:3b55e68f7806bd4a804c9ac871c4e0cc224cc822feb7fa5e0bd7f1bfb4c31cfa"
   name = "github.com/logrusorgru/aurora"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ca24023cc0175fdf372518cb1c5062cc86db2634"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0b67d006d8a1b8034c63c305a32beb7e4bca153f32221368c6942df00bbe5dbb"
   name = "github.com/pquerna/cachecontrol"
   packages = [
     ".",
-    "cacheobject"
+    "cacheobject",
   ]
+  pruneopts = "UT"
   revision = "525d0eb5f91d30e3b1548de401b7ef9ea6898520"
 
 [[projects]]
+  digest = "1:f85e109eda8f6080877185d1c39e98dd8795e1780c08beca28304b87fd855a1c"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:6d3fd61842d17fc8731b167771cfb564d06cb71c75fcb7efbe9b368a6081c1f3"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
-    "ed25519/internal/edwards25519"
+    "ed25519/internal/edwards25519",
   ]
+  pruneopts = "UT"
   revision = "f70185d77e8278766928032ee1355e3da47e7181"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6b719875cf8091fbab38527d81d34e71f4521b9ee9ccfbd4a32cff2ac5af96e"
   name = "golang.org/x/net"
   packages = [
     "context",
-    "context/ctxhttp"
+    "context/ctxhttp",
   ]
+  pruneopts = "UT"
   revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
 
 [[projects]]
   branch = "master"
+  digest = "1:7cb06c9a523660f3c50c6f63f2e2c90052c359b046d2ef1152f2182169dbb720"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = "UT"
   revision = "921ae394b9430ed4fb549668d7b087601bd60a81"
 
 [[projects]]
+  branch = "master"
+  digest = "1:4b487c782bc804d994e91adbd3d2a8a77a482671efd87b2fde0805adb01a39c0"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = "UT"
+  revision = "2b024373dcd9800f0cae693839fac6ede8d64a8c"
+
+[[projects]]
+  digest = "1:9cf45e754ab2dff5f53a553e6948b994ff738e4d1092ca608dcada945d8be0ef"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -81,30 +110,42 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "UT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:0f287957ae25f63e6a9fa361923581db8551e38d6b5e6c4f27e84607b3430889"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
-    "json"
+    "json",
   ]
+  pruneopts = "UT"
   revision = "76dd09796242edb5b897103a75df2645c028c960"
   version = "v2.1.6"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b6baf3a2caebf942aa771e1bc76f436aafd378c5802ce24c8d257ac7231c527"
+  input-imports = [
+    "github.com/coreos/go-oidc",
+    "github.com/logrusorgru/aurora",
+    "github.com/stretchr/testify/assert",
+    "golang.org/x/oauth2",
+    "golang.org/x/sys/unix",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -262,13 +262,13 @@ func switchContext(cluster, config string) {
 	clusterArg := fmt.Sprintf("--cluster=%s", cluster)
 	user := fmt.Sprintf("--user=%s", clientID)
 	cfg := fmt.Sprintf("--kubeconfig=%s", config)
-	cmd := exec.Command("kubectl", "config", "set-context", "kubectl-login-context", user, clusterArg, "--namespace=default", cfg)
+	cmd := exec.Command("kubectl", "config", "set-context", cluster, user, clusterArg, "--namespace=default", cfg)
 	err := cmd.Run()
 	if err != nil {
 		logger.Fatalf("error: cannot set kubectl login context: %v", err)
 	}
 
-	cmd = exec.Command("kubectl", "config", "use-context", "kubectl-login-context", cfg)
+	cmd = exec.Command("kubectl", "config", "use-context", cluster, cfg)
 	err = cmd.Run()
 	if err != nil {
 		logger.Fatalf("error: cannot switch to kubectl login context: %v", err)
@@ -277,6 +277,6 @@ func switchContext(cluster, config string) {
 
 func isLoggedIn(config string) bool {
 	cfg := fmt.Sprintf("--kubeconfig=%s", config)
-	err := exec.Command("kubectl", "get", "configmap", cfg).Run()
+	err := exec.Command("kubectl", "get", "namespace", cfg).Run()
 	return err == nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -434,21 +434,22 @@ func TestSetSwitchContext(t *testing.T) {
 	kubeConfig.Write([]byte(testKubeconfig))
 	kubeConfig.Sync()
 
-	expectedCluster := "k8s-test-publishing-cluster"
-	switchContext(expectedCluster, kubeConfig.Name())
+	expectedCluster := Context{
+		Name: "k8s-test-publishing-cluster",
+		ContextData: ContextData{
+			ClusterName: "k8s-test-publishing-cluster",
+			Namespace: "default",
+			User: "kubectl-login",
+		},
+	}
+	switchContext(expectedCluster.Name, kubeConfig.Name())
 
 	newKubeconfigRaw, _ := ioutil.ReadFile(kubeConfig.Name())
 	newKubeconfig := parseIdTokenConfig(newKubeconfigRaw, t)
-	assert.True(t, len(newKubeconfig.Contexts) > 0)
-	contextFound := false
-	for _, c := range newKubeconfig.Contexts {
-		if c.Name == "kubectl-login-context" {
-			assert.Equal(t, expectedCluster, c.ContextData.ClusterName)
-			contextFound = true
-			break
-		}
-	}
-	assert.True(t, contextFound)
+
+	assert.NotEmpty(t, newKubeconfig.Contexts)
+	assert.Equal(t, expectedCluster.Name, newKubeconfig.CurrentContext)
+	assert.Contains(t, newKubeconfig.Contexts, expectedCluster )
 }
 
 var validConfig = map[string]*configuration{


### PR DESCRIPTION
This allows standard Kubernetes tools to be used to display a sane context.